### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.8",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
@@ -79,7 +80,12 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  const fallbackLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 fallback requests per windowMs
+  });
+
+  app.use("*", fallbackLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/MightyPrytanis/LexFiat/security/code-scanning/2](https://github.com/MightyPrytanis/LexFiat/security/code-scanning/2)

To resolve the missing rate limiting issue, a rate limiting middleware should be applied to any handler performing expensive operations, such as reading files from disk. The best solution in Express is to use a widely known package like `express-rate-limit`. Specifically, before the fallback route `app.use("*", (_req, res) => {...})`, register a rate limiter middleware for this route. This avoids a global rate limit and limits just the expensive fallback. The change involves importing `express-rate-limit`, instantiating a limiter (e.g., 100 requests per 15 minutes), and applying it before the fallback middleware. Add an import for `express-rate-limit` at the top of the file and instantiate the limiter inside the `serveStatic` function.

#### Steps:
- Add `express-rate-limit` import in `server/vite.ts`.
- Instantiate a rate limiter within the `serveStatic` function.
- Apply the limiter middleware before the fallback handler inside `serveStatic`, i.e., before line 82.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
